### PR TITLE
Add latest ubuntu lts and debian stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
           - ubuntu:16.04
           - ubuntu:18.04
           - ubuntu:20.04
+          - ubuntu:22.04
+          - debian:stable
           - debian:testing
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}


### PR DESCRIPTION
Upgrading systems to Jammy, crtime is required.

Starting to use more Debian Stable containers, having crtime available may be handy.